### PR TITLE
refs #13: page link with link text will have unnecessary prefix "http…

### DIFF
--- a/changelog/15.bugfix.rst
+++ b/changelog/15.bugfix.rst
@@ -1,0 +1,1 @@
+image url for gyazo should have `.png` extension on figure directive.

--- a/scrap2rst/converter.py
+++ b/scrap2rst/converter.py
@@ -181,7 +181,7 @@ class Convert:
             m = M['figure'](line)
             result = [
                 '',
-                '.. figure:: ' + m.group(1),
+                f'.. figure:: {m.group(1)}.png',
                 '',
                 ]
             state = (name, None)


### PR DESCRIPTION
…://scrapbox.io/proj/" on conversion.